### PR TITLE
app improvments

### DIFF
--- a/usr/scripts/cnss-gui
+++ b/usr/scripts/cnss-gui
@@ -4,52 +4,117 @@
 # Author: Jerry Bezencon 2015, Ralphy
 # Website: https://www.linuxliteos.com
 #--------------------------------------------
-
 # variables
 APPNAME="Network Share Settings"
 ic="/usr/share/icons/zenity-llcc.png"
-#EALUSER=$(sudo -u ${SUDO_USER:-$USER} whoami)
+host=$(hostname)
+SMBCONF=/etc/samba/smb.conf
+TMPF=/tmp/testparm.txt
+
 if [ $EUID -ne 0 ]; then
     gksu -m '
-<b>Editing Share Settings requires Administrative privileges</b>
+<b>Editing Share Settings requires Administrative privileges   </b>
 
 
                 Please enter your password to continue.' bash $0
    exit
 else :
 fi
+# backup smb.conf file
+if ! [ -f "$SMBCONF.bak" ]; then cp $SMBCONF $SMBCONF.bak; fi
+# set netbios name to hostname in smb.conf
+cat "$SMBCONF" | grep -Fx "netbios name = $host" > /dev/null
+if [[ $? -eq 0 ]]; then :; else
+   zenity --progress --title="$APPNAME" --text="Updating Samba netbios name. Please wait..." --pulsate --no-cancel --width="340" --timeout="4"
+   sed -i "s/netbios name =.*/netbios name = $host/" $SMBCONF
+fi
+# add firewall rule
+sudo ufw allow Samba > /dev/null & 2>&1
 
-zenity --question --width="360"  --icon-name="info" --ok-label="Edit Share Settings" --cancel-label="Cancel" --title="$APPNAME" --window-icon="$ic" \
-       --text="\nYou are about to configure Network Share Settings.\n\n\
-Network Share Settings will open in your text editor. <b>Apply changes carefully.</b>\n\n\
-After you finish editing Network Share Settings, its services must be restarted.\n"
+zenity --question --width="480"  --icon-name="info" --ok-label="Edit Share Settings" --cancel-label="Quit" --title="$APPNAME" --window-icon="$ic" \
+       --text="\nSamba is the software suite that provides seamless file and print services to SMB/CIFS clients. It allows for interoperability between Linux/Unix and Windows-based clients.\n\n
+<b>Reload configuration</b>: When the smb.conf file is changed, Samba automatically reloads it after a few minutes. Issuing a manual reload or restart is just as effective, causing changes to take effect immediately.
+* Network share services are not interrupted while issuing a reload.\n
+<b>Restart services</b>: The restart option is a quick way of stopping and then starting Samba. This is the most reliable way to make configuration changes take effect after editing the configuration file.
+* Network share services are temporarily interrupted while restarting the services.\n"
 
+if [ "$?" -eq "0" ]; then $EDITSHARES; else exit 0; fi
+
+# the loop
 while (true); do
-if [ "$?" -eq "0" ]; then
-EDITSHARES=$(xdg-open /etc/samba/smb.conf )
-unset EDITSHARES
-
-zenity --question --width="300"  --icon-name="info" --default-cancel --ok-label="Edit again" --cancel-label="Restart Share Services" --title="$APPNAME" --window-icon="$ic" \
-       --text="\nReady to restart the Network Share Services or would you like to review the settings one more time?"
-
-    if [ "$?" -eq "0" ]; then
-        continue
+# edit share
+EDITSHARES=$(xdg-open $SMBCONF ) &&
+# md5sum variables
+fingerprintfile=/tmp/.md5savefile
+# create the smb.conf md5sum
+filemd5=`md5sum $SMBCONF | cut -d " " -f1`
+# test smb.conf
+testparm -s /etc/samba/smb.conf 2>&1 | egrep 'Unknown|Ignoring|WARNING|NOTE:|set_variable_helper|Error loading services' >> $TMPF
+# samba testconfig function
+testconfig() {
+if [ -s $TMPF ]; then
+    review=$(zenity --text-info --window-icon="warning" --ok-label="Review configuration" --cancel-label="Continue" --width="460" --height="240" --filename="/tmp/testparm.txt" --title="Configuration errors found" ; echo $?)
+    if [ "$review" -eq "0" ]; then
+      rm -f $TMPF
+      continue
     else
-        RESTARTSHARES=$( stdbuf -oL /bin/bash \-c '(service smbd restart && service nmbd restart && sleep 1 )' 2>&1 |
-        stdbuf -oL sed -n -e 's/^\(.\{128\}\).*/\1/' -e '/\[*$/ s/^/# /p' -e '/\*$/ s/^/# /p' | 
-        zenity --progress --title="Restarting Network Share Services..." --pulsate --no-cancel --width=340 --auto-close )
-        unset RESTARTSHARES
-            if [ "${PIPESTATUS[0]}" -ne "0" ]; then
-                zenity --error \
-                       --title="Error" --text="$APPNAME configuration failed."
-                exit 0
-            else
-                zenity --info timeout=3 --title="$APPNAME" --window-icon="$ic" --width="220" --text="\nYour settings have been applied."
-                exit 0
-            fi
+      egrep 'Error loading services' $TMPF
+      if [ "$?" -eq "0" ]; then
+        rm -f $TMPF
+        zenity --error --width="360" --height="80" --text="\nThe current errors in the configuration will not allow Samba services to run.\n\nPlease correct the configuration."
+        continue
+       fi
     fi
 else
-    exit 0
+echo "$APPNAME - Syntax OK"
 fi
+}
+# call testconfig function
+testconfig
+# warn user when non-critical configuration errors are found
+egrep 'Unknown|Ignoring|WARNING|NOTE:' $TMPF
+if [ "$?" -eq "0" ]; then
+  zenity --warning --width="360" --height="80" --text="\nErrors were found in the configuration.\n\nYou may not be able to access Samba shares until the configuration is corrected."
+fi
+# finally remove temp file
+rm -f $TMPF
+# Is there a saved fingerprint of the config file?
+if [ -f $fingerprintfile ];then
+  # get the saved md5"
+  savedmd5=`cat $fingerprintfile`
+  # compare md5's
+  if [[ "$savedmd5" == "$filemd5" ]]; then
+    zenity --info --timeout="3" --title="$APPNAME" --width="280" --text="\nNo changes to the configuration were made."
+    exit 0
+  else
+    :
+  fi
+fi
+# save the current md5
+echo $filemd5 > $fingerprintfile
+
+zenity --question --width="360"  --icon-name="info" --default-cancel --cancel-label="Reload configuration" --ok-label="Restart services" --title="$APPNAME" --window-icon="$ic" \
+       --text="\nChanges in the configuration file have been detected.\n
+When the configuration file is modified, Samba automatically reloads it after a few minutes. You can manually reload or restart the services \
+for changes to apply immediately.\n"
+
+if [ "$?" -eq "1" ]; then
+  killall -HUP smbd nmbd &&
+zenity --info --timeout="3" --title="$APPNAME" --width="220" --text="\nThe configuration has been reloaded."
+exit
+else
+  RESTARTSHARES=$( stdbuf -oL /bin/bash \-c '(systemctl restart smbd nmbd && sleep .5 )' 2>&1 |
+  stdbuf -oL sed -n -e 's/^\(.\{128\}\).*/\1/' -e '/\[*$/ s/^/# /p' -e '/\*$/ s/^/# /p' |
+  zenity --progress --title="$APPNAME" --text="✔ Restarting network share services..." --pulsate --no-cancel --width=340 --auto-close )
+  unset RESTARTSHARES
+      if [ "${PIPESTATUS[0]}" -ne "0" ]; then
+        zenity --error \
+               --title="Error" --text="$APPNAME configuration failed."
+        exit 0
+      else
+          zenity --info --timeout="5" --title="$APPNAME" --window-icon="$ic" --width="230" --text="\nYour settings have been applied.\nSamba services have been restarted."
+          exit 0
+      fi
+    fi
 done
 exit 0


### PR DESCRIPTION
Fixes:
* NSS Quit button on first dialog now cancels the application.

Improvements:
* NSS now creates a smb.conf backup copy in /etc/samba/smb.conf.bak on
first launch
* NSS checks if smb.conf.bak file exists not to duplicate it or
overwrite it on subsequent launches  (smb.conf.bak will remain a copy
of the original smb.conf file)
* NSS now checks that samba setting netbios name = hostname in
/etc/samba/smb.conf on every launch. If not, it will set it accordingly.
* NSS now creates UFW rules on first launch to allow Samba through the
firewall
* NSS checks smb.conf for warning or errors and prompts the user to
correct the configuration.
If the configuration error is not critical, NSS allows users to
move forward and and restart NSS services
If the configuration error is critical, NSS will not allow the
service to be restarted. Instead it loops to the configuration for
adjustments.
* Added option to reload configuration instead of restarting samba
services